### PR TITLE
Restructure CI: separate link-checking from deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,16 +2,14 @@ name: Deploy MkDocs to Azure Static Web Apps
 
 on:
   push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches: [main]
 
 jobs:
-  build_and_deploy:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+  check_links:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    name: Build and Deploy
+    name: Check Links
     steps:
       - uses: actions/checkout@v4
 
@@ -39,10 +37,30 @@ jobs:
             --exclude '^https://.*\.fgov\.be/'
             --exclude '^https://mobiliteitsbudget\.be/'
             --exclude '^https://marketplace\.microsoft\.com/'
+            --exclude '^https://mobilevikings\.be/'
+            --exclude '^https://selfservice\.officient\.io/'
             site/
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    name: Build and Deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
Split the single build_and_deploy job into two:
- check_links runs on all branches (push + PR, except PR-close)
- build_and_deploy runs only on push to main

Also exclude bot-blocking sites mobilevikings.be and selfservice.officient.io from lychee link checks.